### PR TITLE
Readme: task.loadNpmTasks > grunt.loadNpmTasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Compare file sizes on this branch to master
 
 Add this to your project's `Gruntfile.js` gruntfile:
 ```javascript
-task.loadNpmTasks('grunt-compare-size');
+grunt.loadNpmTasks('grunt-compare-size');
 ```
 
 Then add "grunt-compare-size" to your package.json dependencies.


### PR DESCRIPTION
Either `grunt.loadNpmTasks` or `grunt.task.loadNpmTasks`.
